### PR TITLE
Fix argument not provided during a function call, also remove unused import.

### DIFF
--- a/task_manager/logger.py
+++ b/task_manager/logger.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import logging
 
 class Log:

--- a/task_manager/storage.py
+++ b/task_manager/storage.py
@@ -12,7 +12,7 @@ class TaskStorage:
             with open(TASKS_FILE, "r") as file:
                 return json.load(file)
         else:
-            Log.debug("[-TaskStorage-]", "Tasks file not found.")
+            Log.debug("[-TaskStorage-]", "Tasks file not found.", "")
         return []
 
     @staticmethod


### PR DESCRIPTION
Fix argument not being provided for Log.debug() when called at TaskStorage.load_tasks().